### PR TITLE
Change ollama endpoint to .ollama_server argument

### DIFF
--- a/R/api_functions.R
+++ b/R/api_functions.R
@@ -476,7 +476,7 @@ ollama <- function(.llm,
   if(.json==TRUE){ollama_request_body$format <- "json"}
   
   #Build the request
-  ollama_api <- httr2::request("http://localhost:11434/") |>
+  ollama_api <- httr2::request(.ollama_server) |>
     httr2::req_url_path("/api/chat") 
   
   assistant_reply <- NULL


### PR DESCRIPTION
The .ollama_server argument is available, but the URL is hardcoded in the function. 